### PR TITLE
feat: use GH graphql api to measure both merged and assignees

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,14 +51,59 @@ pub enum AirTableViews {
     Approved,
 }
 
-#[derive(Deserialize)]
-pub struct PullRequest {
-    id: u64,
-    number: u64,
-    pub assignees: Vec<Assignees>,
+#[derive(Debug, Deserialize)]
+pub struct Assignees {
+    pub nodes: Vec<User>,
 }
 
-#[derive(Deserialize)]
-pub struct Assignees {
+#[derive(Debug, Deserialize)]
+pub struct User {
     pub login: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PageInfo {
+    pub endCursor: Option<String>,
+    pub hasNextPage: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLError {
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct GraphQLQuery {
+    pub query: String,
+    pub variables: Variables,
+}
+
+#[derive(Serialize)]
+pub struct Variables {
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResponseData {
+    pub data: Option<RepositoryData>,
+    pub errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepositoryData {
+    pub search: Search,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Search {
+    issueCount: u32,
+    pub nodes: Vec<PullRequestNode>,
+    pub pageInfo: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullRequestNode {
+    number: u32,
+    pub mergedBy: Option<User>,
+    pub assignees: Assignees,
 }


### PR DESCRIPTION
Would be cool to graph both.
This is what the output now looks like for me:
```
# HELP airtable_records Number of Approved Airtable Records
# TYPE airtable_records gauge
airtable_records 0
# HELP airtable_records_pending Number of Pending Airtable Records
# TYPE airtable_records_pending gauge
airtable_records_pending 0
# HELP avg_grant Average dollars given per grant
# TYPE avg_grant gauge
avg_grant 80.35166666666667
# HELP pr_merger_stats Number of pull requests reviewed by each reviewer
# TYPE pr_merger_stats gauge
pr_merger_stats{reviewer="24c02"} 23
pr_merger_stats{reviewer="46-HA"} 7
pr_merger_stats{reviewer="Leo32345"} 9
pr_merger_stats{reviewer="Lightshayan"} 9
pr_merger_stats{reviewer="LimesKey"} 66
pr_merger_stats{reviewer="MichaByte"} 19
pr_merger_stats{reviewer="daisybanks"} 26
pr_merger_stats{reviewer="karmanyaahm"} 92
pr_merger_stats{reviewer="kvnyng"} 52
pr_merger_stats{reviewer="maxwofford"} 84
pr_merger_stats{reviewer="sarthaktexas"} 13
pr_merger_stats{reviewer="torbers"} 11
# HELP pr_reviewer_stats Number of pull requests reviewed by each reviewer
# TYPE pr_reviewer_stats gauge
pr_reviewer_stats{reviewer="24c02"} 19
pr_reviewer_stats{reviewer="46-HA"} 7
pr_reviewer_stats{reviewer="Lightshayan"} 9
pr_reviewer_stats{reviewer="LimesKey"} 65
pr_reviewer_stats{reviewer="MichaByte"} 11
pr_reviewer_stats{reviewer="karmanyaahm"} 20
pr_reviewer_stats{reviewer="kvnyng"} 9
pr_reviewer_stats{reviewer="maxwofford"} 56
pr_reviewer_stats{reviewer="torbers"} 5
# HELP prometheus_exporter_request_duration_seconds The HTTP request latencies in seconds.
# TYPE prometheus_exporter_request_duration_seconds histogram
prometheus_exporter_request_duration_seconds_bucket{le="0.005"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.01"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.025"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.05"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.1"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.25"} 0
prometheus_exporter_request_duration_seconds_bucket{le="0.5"} 0
prometheus_exporter_request_duration_seconds_bucket{le="1"} 0
prometheus_exporter_request_duration_seconds_bucket{le="2.5"} 0
prometheus_exporter_request_duration_seconds_bucket{le="5"} 0
prometheus_exporter_request_duration_seconds_bucket{le="10"} 0
prometheus_exporter_request_duration_seconds_bucket{le="+Inf"} 1
prometheus_exporter_request_duration_seconds_sum 38.165528119
prometheus_exporter_request_duration_seconds_count 1
# HELP prometheus_exporter_requests_total Number of HTTP requests received.
# TYPE prometheus_exporter_requests_total counter
prometheus_exporter_requests_total 1
# HELP submitted_projects Number of folders in the projects directory in the OnBoard Github
# TYPE submitted_projects gauge
submitted_projects 0
# HELP transfers_count Grant transfers out of the OnBoard Hack Club Bank
# TYPE transfers_count gauge
transfers_count 600
```
